### PR TITLE
Use strict equality for type checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,7 +680,7 @@ class Selection {
   }
 
   #makeSelectFunction(selectorOrFunction) {
-    if (typeof selectorOrFunction == "string") {
+    if (typeof selectorOrFunction === "string") {
       return function () {
         return this.querySelector(selectorOrFunction);
       };
@@ -698,7 +698,7 @@ class Selection {
   }
 
   static getValue(valueOrFunction, __data__) {
-    if (typeof valueOrFunction == "function") {
+    if (typeof valueOrFunction === "function") {
       return valueOrFunction(__data__);
     } else if (["number", "string"].includes(typeof valueOrFunction)) {
       return String(valueOrFunction);

--- a/mini-d3.js
+++ b/mini-d3.js
@@ -53,7 +53,7 @@ class Selection {
   }
 
   #makeSelectFunction(selectorOrFunction) {
-    if (typeof selectorOrFunction == "string") {
+    if (typeof selectorOrFunction === "string") {
       return function () {
         return this.querySelector(selectorOrFunction);
       };
@@ -71,7 +71,7 @@ class Selection {
   }
 
   static getValue(valueOrFunction, __data__) {
-    if (typeof valueOrFunction == "function") {
+    if (typeof valueOrFunction === "function") {
       return valueOrFunction(__data__);
     } else if (["number", "string"].includes(typeof valueOrFunction)) {
       return String(valueOrFunction);


### PR DESCRIPTION
## Summary
- use strict equality for selector and value type checks
- update README examples to reflect strict type checking

## Testing
- `npm test`
- `npm run check:format`


------
https://chatgpt.com/codex/tasks/task_e_68ba9b8a5cdc832ba5c18d1a85b920ac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes in this release.
- Documentation
  - Updated README examples to use strict equality in type checks for clearer, more accurate guidance.
- Style
  - Standardized internal type comparisons to strict equality for improved consistency; no behavior or API changes expected.
- Chores
  - Minor code quality improvements to align with best practices without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->