### PR TITLE
docs: mention key D3 features in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![Bar chart drawn with mini D3 (with scaling)](.readme/bars-with-scaling.png)
 
-To use [D3] effectively while understanding its internal workings, it's important to grasp these features in advance.
-To help with this, I created a script called [mini-d3.js] and its [bar chart demo] that can draw simple charts using a D3-like API.
+To use [D3] effectively while understanding its internal workings, it's important to grasp features like the selection API, scale, and axis in advance.
+To help with this, I created a script called [mini-d3.js] and its [bar chart demo] that demonstrate these features using a D3-like API.
 
 [D3]: https://github.com/d3/d3
 [mini-d3.js]: https://github.com/oshikiri/build-your-own-d3/blob/main/mini-d3.js


### PR DESCRIPTION
## Summary
- list selection API, scale, and axis in README introduction
- remove links to internal sections per review feedback

## Testing
- `npm test`
- `npm run check:format`


------
https://chatgpt.com/codex/tasks/task_e_68ba9c581998832b966f8d300907f833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README introduction to clearly list key capabilities (selection API, scales, and axes) for improved clarity.
  * Revised demo description to state it showcases these capabilities using a D3-like API.
  * Enhanced readability and guidance to help new users understand what to explore and how the demo relates to the features.
  * Clarifies expectations without altering functionality; no code or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->