### PR TITLE
refactor: use method shorthand consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Based on this information, let's add a `Selection` class as shown below[^origina
 
   <script>
     const d3 = {
-      select: function (selector) {
+      select(selector) {
         const el = document.querySelector(selector);
         return new Selection(el);
       },
@@ -287,7 +287,7 @@ For reference, here is the complete source code.
 
   <script>
     const d3 = {
-      select: function (selector) {
+      select(selector) {
         const el = document.querySelector(selector);
         return new Selection(el);
       },
@@ -438,7 +438,7 @@ The `d3.json` function simply returns a `Promise`, so the following implementati
 **d3 definition in examples/load-json/myd3.html:**
 ```js
 const d3 = {
-  select: function (selector) {
+  select(selector) {
     const el = document.querySelector(selector);
     return new Selection(el);
   },
@@ -493,7 +493,7 @@ However, for the sake of step-by-step explanation, this document keeps all imple
 **examples/setup-package/myd3.js:**
 ```js
 const d3 = {
-  select: function (selector) {
+  select(selector) {
     const el = document.querySelector(selector);
     return new Selection(el);
   },
@@ -629,11 +629,11 @@ Based on the implementation of d3-selection, let's add the following implementat
 **examples/bar-chart/bars/myd3.js:**
 ```js
 const d3 = {
-  select: function (selector) {
+  select(selector) {
     const element = document.querySelector(selector);
     return new Selection([[element]], [document.documentElement]);
   },
-  json: async function (path) {
+  async json(path) {
     return fetch(path).then((response) => response.json());
   },
   scaleBand,

--- a/demo/insert-text/myd3.html
+++ b/demo/insert-text/myd3.html
@@ -5,7 +5,7 @@
 
   <script>
     const d3 = {
-      select: function (selector) {
+      select(selector) {
         const el = document.querySelector(selector);
         return new Selection(el);
       },

--- a/demo/rectangle/myd3.html
+++ b/demo/rectangle/myd3.html
@@ -5,7 +5,7 @@
 
   <script>
     const d3 = {
-      select: function (selector) {
+      select(selector) {
         const el = document.querySelector(selector);
         return new Selection(el);
       },

--- a/mini-d3.js
+++ b/mini-d3.js
@@ -1,9 +1,9 @@
 const d3 = {
-  select: function (selector) {
+  select(selector) {
     const element = document.querySelector(selector);
     return new Selection([[element]], [document.documentElement]);
   },
-  json: async function (path) {
+  async json(path) {
     return fetch(path).then((response) => response.json());
   },
   scaleBand,


### PR DESCRIPTION
## Summary
- refactor `d3.json` to use method shorthand
- switch demo `select` implementations to method shorthand
- update README examples for concise method definitions

## Testing
- `npm test`
- `npm run check:format`

>モダンな JavaScript が推奨するメソッド定義は、MDN の「Method definitions」にて正式な構文として紹介されており、冗長な function キーワードを省くことでコード量の削減と可読性向上が期待できます。既に本プロジェクトでは async/await など ES2015 以降の機能を取り入れているため、メソッド短縮記法を導入しても対応環境の要件に新たな影響はありません。


------
https://chatgpt.com/codex/tasks/task_e_68c2fd8a3a8c832bad43c8969bdf32d7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Documentation
  - Modernized code examples to use ES6 method shorthand and async method syntax across guides and demos.
  - Improved readability and consistency of examples without altering behavior.
  - No changes to the public API or example outcomes; existing usage remains valid.

- Style
  - Updated example code formatting for clarity and alignment with contemporary JavaScript conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->